### PR TITLE
Stop crown perimeter being unique by tree

### DIFF
--- a/app/classes/importers/crown_perimeter_importer.rb
+++ b/app/classes/importers/crown_perimeter_importer.rb
@@ -6,10 +6,9 @@ class CrownPerimeterImporter < RowImporter
 
   def read_row(values, logger)
 
-    @cp = find_or_new({
-      :tree => find_tree(values[3])
-    })
-    attempt_to_overwrite!(@cp)
+    @cp = CrownPerimeter.new
+    @cp.tree = find_tree values[3]
+    @cp.batch_id = @batch_id
 
     @cp.seq = values[4]
     @cp.sun = nil_if_na values[5]


### PR DESCRIPTION
Example code for making crown perimeters not be unique by tree anymore. But I have not tested this :-)

Fixes #38.